### PR TITLE
Detect icu4c error codes more precisely

### DIFF
--- a/c_bridge.c
+++ b/c_bridge.c
@@ -6,16 +6,16 @@
 #include <unicode/ucnv.h>
 
 // See description in c_bridge.h
-const int detectCharset(void        *detector, 
-                        void        *input, 
-                        int         input_len, 
-                        int         *status, 
-                        MatchData   *matchBuffer, 
+const int detectCharset(void        *detector,
+                        void        *input,
+                        int         input_len,
+                        int         *status,
+                        MatchData   *matchBuffer,
                         int         matchBufferSize) {
 
     // Put input bytes in the detector.
     ucsdet_setText((UCharsetDetector*)detector, (char*)input, input_len, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 
@@ -25,7 +25,7 @@ const int detectCharset(void        *detector,
 
     // Perform analysis and return all guesses and their count.
     bestGuesses = ucsdet_detectAll((UCharsetDetector*)detector, &matchCount, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 
@@ -42,19 +42,19 @@ const int detectCharset(void        *detector,
 
         // Fill guessed encoding
         bestGuessedCharset = ucsdet_getName(bestGuess, status);
-        if (*status != U_ZERO_ERROR) {
+        if U_FAILURE(*status) {
             return 0;
         }
 
         // Fill guessed language
         bestGuessedLanguage = ucsdet_getLanguage(bestGuess, status);
-        if (*status != U_ZERO_ERROR) {
+        if U_FAILURE(*status) {
             return 0;
         }
 
         // Fill its confidence rating
         int32_t conf = ucsdet_getConfidence(bestGuess, status);
-        if (*status != U_ZERO_ERROR) {
+        if U_FAILURE(*status) {
             return 0;
         }
 
@@ -69,7 +69,7 @@ const int detectCharset(void        *detector,
 
 // See description in c_bridge.h
 int convertToUtf16(const char   *srcEncoding,
-                   UChar        *dest, 
+                   UChar        *dest,
                    int32_t      destCapacity,
                    const char   *src,
                    int32_t      srcLength,
@@ -77,13 +77,13 @@ int convertToUtf16(const char   *srcEncoding,
     UConverter *conv;
 
     conv = ucnv_open(srcEncoding, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 
     /* Convert from original encoding to UTF-16 */
     int len = ucnv_toUChars(conv, dest, destCapacity, src, srcLength, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 
@@ -94,7 +94,7 @@ int convertToUtf16(const char   *srcEncoding,
 
 // See description in c_bridge.h
 int convertFromUtf16(const char   *destEncoding,
-                     char         *dest, 
+                     char         *dest,
                      int32_t      destCapacity,
                      const UChar  *src,
                      int32_t      srcLength,
@@ -102,13 +102,13 @@ int convertFromUtf16(const char   *destEncoding,
     UConverter *conv;
 
     conv = ucnv_open(destEncoding, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 
     /* Convert from UTF-16 to destination encoding */
     int len = ucnv_fromUChars(conv, dest, destCapacity, src, srcLength, status);
-    if (*status != U_ZERO_ERROR) {
+    if U_FAILURE(*status) {
         return 0;
     }
 

--- a/convert.go
+++ b/convert.go
@@ -14,7 +14,7 @@ const (
     DefaultMaxTextSize = 1024 * 1024    // Default value for the max text length in conversion operations
     utf8MaxCharSize = 4
     utf16MaxCharSize = 4
-) 
+)
 
 var (
     Utf8CString = C.CString("UTF-8")
@@ -35,7 +35,7 @@ type CharsetConverter struct {
 // are created in memory once and then used. 'maxTextSize' sets the size of these buffers.
 // ICU library would return error if any processed text is longer than this parameter.
 //
-// NOTE: 
+// NOTE:
 //
 // UTF8 uses 1 to 4 bytes for each symbol.
 // UTF16 uses 2 bytes to 4 bytes for each symbol.
@@ -79,7 +79,7 @@ func (conv *CharsetConverter) ConvertToUtf8(input []byte, srcEncoding string) ([
             C.int32_t(len(input)),
             (*C.int)(unsafe.Pointer(&status)))
 
-    if status == U_ZERO_ERROR {
+    if isSuccess(status) {
         nConvLen := C.convertFromUtf16(
             Utf8CString,
             (*C.char)(unsafe.Pointer(&conv.utf8Buffer[0])),
@@ -88,7 +88,7 @@ func (conv *CharsetConverter) ConvertToUtf8(input []byte, srcEncoding string) ([
             C.int32_t(convLen),
             (*C.int)(unsafe.Pointer(&status)))
 
-        if status == U_ZERO_ERROR {
+        if isSuccess(status) {
             resStr := conv.utf8Buffer[:nConvLen]
             return ([]byte)(resStr), nil
         }


### PR DESCRIPTION
Negative values are warnings, not errors; failing on them breaks encoding when
it would otherwise work.

Unfortunately, these negative numbers are being converted into large positive
ones through the cgo bridge, so this becomes a slightly more complicated
check than necessary.